### PR TITLE
Fully support *.spec.ts

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "test:watch": "jest --env=jsdom --watch --updateSnapshot",
     "prepublishOnly": "npm run build",
     "prebuild": "npm run clean",
-    "postbuild": "rimraf {lib,es}/**/__tests__",
+    "postbuild": "rimraf {lib,es}/**/__tests__ {lib,es}/**/*.{spec,test}.{js,d.ts,js.map}",
     "posttest": "npm run typecheck && npm run lint",
     "preversion": "npm test",
     "postversion": "git push && git push --tags"


### PR DESCRIPTION
In [`jest.config.js`](https://github.com/maxdavidson/typescript-library-boilerplate/blob/a92daf558813e480efcb1351c2620136846f4c04/jest.config.js) an alternative structure to keep tests next to the sourcecode named `*.spec.ts` or `*.test.ts` seems to be supported. But the script to clean out the tests after building did not support this.