### PR TITLE
Fix travis builds failing sometimes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ node_js:
   - stable
 cache:
   directories:
-    - node_modules
+    - $HOME/.npm
 after_success:
   - npm i -g coveralls
   - cat coverage/lcov.info | coveralls


### PR DESCRIPTION
Sometimes builds can fail because the cached `node_modules` is compiled for another version of node. 

https://travis-ci.org/oBusk/typescript-library-boilerplate/jobs/405472546

The normally accepted solution seems to be to cache the npm global cache rather than the compiled `node_modules`.

* https://stackoverflow.com/a/42523517/1433417
* https://docs.npmjs.com/cli/ci