### PR TITLE
Fix VS Code debugging 

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,7 +5,7 @@
     "type": "node",
     "request": "launch",
     "protocol": "inspector",
-    "program": "${workspaceRoot}/node_modules/jest/bin/jest.js",
+    "program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
     "args": [
       "--env=jsdom",
       "--no-cache",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,7 +1,7 @@
 {
   "version": "0.2.0",
   "configurations": [{
-    "name": "Debug",
+    "name": "Run Related Tests",
     "type": "node",
     "request": "launch",
     "program": "${workspaceFolder}/node_modules/.bin/jest",
@@ -11,6 +11,25 @@
       "--runInBand",
       "--findRelatedTests",
       "${relativeFile}"
+    ],
+    "console": "integratedTerminal",
+    "internalConsoleOptions": "neverOpen",
+    "skipFiles": [
+      "<node_internals>/**/*.js"
+    ],
+    "windows": {
+      "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+    }
+  },
+  {
+    "name": "Run All Tests",
+    "type": "node",
+    "request": "launch",
+    "program": "${workspaceFolder}/node_modules/.bin/jest",
+    "args": [
+      "--env=jsdom",
+      "--no-cache",
+      "--runInBand"
     ],
     "console": "integratedTerminal",
     "internalConsoleOptions": "neverOpen",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,7 @@
       "--no-cache",
       "--runInBand",
       "--findRelatedTests",
-      "${file}"
+      "${relativeFile}"
     ],
     "skipFiles": [
       "<node_internals>/**/*.js"

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -4,8 +4,7 @@
     "name": "Debug",
     "type": "node",
     "request": "launch",
-    "protocol": "inspector",
-    "program": "${workspaceFolder}/node_modules/jest/bin/jest.js",
+    "program": "${workspaceFolder}/node_modules/.bin/jest",
     "args": [
       "--env=jsdom",
       "--no-cache",
@@ -13,8 +12,14 @@
       "--findRelatedTests",
       "${relativeFile}"
     ],
+    "console": "integratedTerminal",
+    "internalConsoleOptions": "neverOpen",
     "skipFiles": [
       "<node_internals>/**/*.js"
-    ]
-  }]
+    ],
+    "windows": {
+      "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+    }
+  },
+]
 }

--- a/src/__tests__/index.ts
+++ b/src/__tests__/index.ts
@@ -1,13 +1,8 @@
 import { HelloWorld, doSomethingAsync } from '..';
-import * as utils from '../utils';
 
 test('hello world', () => {
   const thing = new HelloWorld('neat');
   expect(thing.getMessage()).toBe('Hello, this is neat');
-});
-
-test('utils', () => {
-  expect(utils.add(1, 4)).toBe(5);
 });
 
 test('async', async () => {

--- a/src/__tests__/utils.ts
+++ b/src/__tests__/utils.ts
@@ -1,0 +1,5 @@
+import * as utils from '../utils';
+
+test('utils', () => {
+  expect(utils.add(1, 4)).toBe(5);
+});


### PR DESCRIPTION
The VS Code launch configuration was outdated and was not working on my windows machine(s). 
I updated the scripts following the recommendations on https://github.com/Microsoft/vscode-recipes/tree/master/debugging-jest-tests 

As a part to make sure that the `relatedFiles` flag was working, i also splitted the tests in two, something that maybe should be reverted, but it also makes for a sensible structure.